### PR TITLE
Fixed denied access status generating code

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/approval/ApprovalStoreUserApprovalHandler.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/approval/ApprovalStoreUserApprovalHandler.java
@@ -140,8 +140,8 @@ public class ApprovalStoreUserApprovalHandler implements UserApprovalHandler, In
 		Date today = new Date();
 		for (Approval approval : userApprovals) {
 			if (approval.getExpiresAt().after(today)) {
-				validUserApprovedScopes.add(approval.getScope());
 				if (approval.getStatus() == ApprovalStatus.APPROVED) {
+					validUserApprovedScopes.add(approval.getScope());
 					approvedScopes.add(approval.getScope());
 				}
 			}


### PR DESCRIPTION
I've noticed that when you get a access_denied error, and you persist your approval grants to a DB, you would get a DENIED approval record. Without this change, all scopes are being added to validUserApprovalScopes which would cause authorizationRequest to be approved, even though all of the userApprovals could be with status DECLINED.

I've created an issue for this.
